### PR TITLE
Use the git_install_path when determining the git version

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -24,7 +24,7 @@
     state: present
 
 - name: Get installed version.
-  command: git --version
+  command: "{{ git_install_path }}/bin/git --version"
   changed_when: false
   failed_when: false
   check_mode: false


### PR DESCRIPTION
There are a few small issues that break idempotence when a custom `git_install_path` is used:
1. When `{{ git_install_path}}/bin` isn't in the PATH environment variable
2. When `{{ git_install_path}}/bin` has a lower precedence than a system installed version of git

Presumably when `git_install_path` is used, the expectation is that git will be built and installed under the following conditions:
- if git isn't present on that path or...
- the version of git found under `{{ git_install_path}}/bin` is different to the version specified in `git_version`

This proposed change ensures that you always check the specific git executable found at the path defined in `git_install_path` and don't accidentally pick up any other git installation.